### PR TITLE
Fix/11 bug ks secret vault operator creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,40 @@
 [![GitHub release](https://img.shields.io/github/release/finleap-connect/vaultoperator.svg)](https://github.com/finleap-connect/vaultoperator/releases)
 
 The `vault-operator` provides several CRDs to interact securely and indirectly with secrets.
+
+## Quick start
+
+Add the helm repository to your list of repos:
+
+```bash
+$ helm repo add finleap-connect https://finleap-connect.github.io/charts/
+$ helm repo update
+```
+
+Execute the following to get the complete list of values available:
+
+```bash
+helm show values finleap-connect/vault-operator --version <VERSION>
+```
+
+Configure at least the following settings within your `values.yaml` :
+```yaml
+# Configure Vault connection
+vault:
+  addr: "" # Address of the Vault instance
+  tls:
+    secretName: "" # Specify secret containing CA to access Vault
+  credentials:
+    secretName: "" # Specify secret containing AppRole credentials as fields VAULT_ROLE_ID and VAULT_SECRET_ID, see https://www.vaultproject.io/docs/auth/approle
+  namespace: "" # Which Vault namespace to connect to
+```
+
+Install VaultOperator with the following command:
+
+```bash
+$ helm install finleap-connect/vault-operator --name myrealease --version <VERSION> --values values.yaml
+```
+
 ## Details
 
 Currently only _stage 1_ is implemented, which includes the `VaultSecret`-CRD.
@@ -97,4 +131,3 @@ The test suite needs the kubebuilder assets. If they are not installed in the de
 path make sure to set `KUBEBUILDER_ASSETS` before running tests.
 Similarly the vault CLI needs to be setup, if it is outside your `PATH` make sure to
 set `VAULT_ASSETS` to the directory containing the vault executable.
-

--- a/charts/vault-operator/templates/configmap.yaml
+++ b/charts/vault-operator/templates/configmap.yaml
@@ -5,6 +5,6 @@ metadata:
   labels:
     {{- include "vault-operator.labels" . | nindent 4 }}
 data:
-  VAULT_ADDR: {{ .Values.vault.addr }}
+  VAULT_ADDR: {{ required "A valid .Values.vault.addr is required!" .Values.vault.addr }}
   VAULT_NAMESPACE: {{ .Values.vault.namespace | quote }}
   SHARED_PATHS: {{ join "," .Values.sharedPaths | quote }}

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - configMapRef:
             name: vault-operator-env
         - secretRef:
-            name: vault-operator-creds
+            name: {{ required "A valid .Values.vault.credentials.secretName is required!" .Values.vault.credentials.secretName }}
         ports:
         - containerPort: 443
           name: webhook-server
@@ -79,7 +79,7 @@ spec:
       {{- if .Values.vault.tls.secretName }}
       - name: tls-certs
         secret:
-          secretName: {{ .Values.vault.tls.secretName }}
+          secretName: {{ required "A valid .Values.vault.tls.secretName is required!" .Values.vault.tls.secretName }}
       {{- end }}
 
 

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -36,16 +36,18 @@ securityContext: {}
 
 terminationGracePeriodSeconds: 10
 
-# Set this to false for GKE, which runs a CertManager, which only
+# Set this to false for older CertManager, which only
 # supports the cert-manager.io/v1 API
 useOldCertManager: true
 
 # Configure Vault connection
 vault:
-  addr: "" # Address of the Vault instance
+  addr: "" # Required address of Vault
   tls:
-    secretName: "" # Specify secret containing CA to access Vault
-  namespace: "" # Which Vault namespace to connect to
+    secretName: "" # Required secret containing CA to access Vault
+  credentials:
+    secretName: "" # Required secret containing AppRole credentials as fields VAULT_ROLE_ID and VAULT_SECRET_ID, see https://www.vaultproject.io/docs/auth/approle
+  namespace: "" # Optional Vault namespace to connect to
 
 # Set which paths in Vault are allowed to be accessed from any namespace
 sharedPaths:


### PR DESCRIPTION
Fix for https://github.com/finleap-connect/vaultoperator/issues/11. Added ability to set secret name via helm chart and added installation instructions.