### PR TITLE
make external kubeconfig configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ testbin/*
 cover.out
 .vscode
 .coverprofile
+.dccache

--- a/charts/vault-operator/templates/deployment.yaml
+++ b/charts/vault-operator/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             name: vault-operator-env
         - secretRef:
             name: {{ required "A valid .Values.vault.credentials.secretName is required!" .Values.vault.credentials.secretName }}
+        {{- if .Values.kubeconfig.secretName }}
+        env:
+        - name: KUBECONFIG
+          value: /opt/kube/kubeconfig
+        {{- end }}
         ports:
         - containerPort: 443
           name: webhook-server
@@ -55,6 +60,11 @@ spec:
         - name: tls-certs
           mountPath: /etc/ssl/certs/
           readOnly: true
+        {{- end }}
+        {{- if .Values.kubeconfig.secretName }}
+        - name: kubeconfig
+          mountPath: /opt/kube
+          readonly: true
         {{- end }}
         resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -81,5 +91,13 @@ spec:
         secret:
           secretName: {{ required "A valid .Values.vault.tls.secretName is required!" .Values.vault.tls.secretName }}
       {{- end }}
-
-
+      {{- if .Values.kubeconfig.secretName }}
+      - name: kubeconfig                                                                                                                                                                                                 │
+│       secret:                                                                                                                                                                                                          │
+│         defaultMode: 420                                                                                                                                                                                               │
+│         items:                                                                                                                                                                                                         │
+│         - key: kubeconfig                                                                                                                                                                                              │
+│           mode: 256                                                                                                                                                                                                    │
+│           path: kubeconfig                                                                                                                                                                                             │
+│         secretName: {{ .Values.kubeconfig.secretName }}
+      {{- end }}

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -45,6 +45,9 @@ vault:
     secretName: "" # Required secret containing AppRole credentials as fields VAULT_ROLE_ID and VAULT_SECRET_ID, see https://www.vaultproject.io/docs/auth/approle
   namespace: "" # Optional Vault namespace to connect to
 
+#kubeconfig:
+#  secretName: "garden-kubeconfig-for-admin"
+
 # Set which secret engines are allowed to access namespaced
 allowedSecretEngines:
   - app


### PR DESCRIPTION
Signed-off-by: Christian Hüning <christian.huening@finleap.com>

allow to configure an external kubeconfig from a secret