### PR TITLE
makes rbac deployment configurable

### DIFF
--- a/charts/vault-operator/templates/manager-rbac.yaml
+++ b/charts/vault-operator/templates/manager-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployRBACs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -59,3 +60,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "vault-operator.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/vault-operator/templates/metrics-rbac.yaml
+++ b/charts/vault-operator/templates/metrics-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployRBACs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -9,3 +10,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{- end }}

--- a/charts/vault-operator/templates/proxy-rbac.yaml
+++ b/charts/vault-operator/templates/proxy-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployRBACs }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -30,3 +31,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "vault-operator.serviceAccountName" . }}
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/vault-operator/values.yaml
+++ b/charts/vault-operator/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 deployCRDs: false
+deployRBACs: true
 
 replicaCount: 1
 


### PR DESCRIPTION
Signed-off-by: Christian Hüning <christian.huening@finleap.com>

introduce `.Values.deployRBACs` to configure deployment of cluster-wide RBACs